### PR TITLE
Mafft more explicit parameters

### DIFF
--- a/omgene.py
+++ b/omgene.py
@@ -31,6 +31,8 @@ __credits__ = "Michael Dunne, Steve Kelly"
 ################ Safely import packages ################
 ########################################################
 
+import numpy as np
+
 errors = []
 libnames = ["csv", "re", "os", "sys", "itertools", "copy", "subprocess", "multiprocessing", \
 	"commands", "datetime", "tempfile", "pickle", "string", "pyfaidx", "argparse", \
@@ -65,8 +67,8 @@ except ImportError as e:
         errors.append(e)
 try:
 	from scipy.special import binom as bn
-except ImportError as 
-        errors.append(e)
+except ImportError as e: 
+       errors.append(e)
 
 if errors:
         print("Missing modules :(\nThe following module errors need to be resolved before running OMGene:")

--- a/omgene.py
+++ b/omgene.py
@@ -1098,7 +1098,7 @@ def prepareGeneregions(dict_seqInfo, dict_genomeInfo, path_wDir, int_numCores, i
 		path_allBaseLoci	= path_gDir + "/" + genomeId + ".bases"
 		path_mergedBaseLoci	= path_gDir + "/" + genomeId + ".bases.merged"
 		concatFiles(bases_tight, path_allBaseLoci)
-		callFunction("sort -k1,1V -k4,4n " + path_allBaseLoci + " | bedtools merge -s -i - > " + path_mergedBaseLoci)
+		callFunction("sort -k1,1V -k4,4n " + path_allBaseLoci + " | bedtools merge -s -c 4,5,6,7 -o distinct,distinct,distinct,distinct -i - > " + path_mergedBaseLoci)
 		sequences = [copy.deepcopy(a) for a in dict_seqInfo.values() if a["genome"] == path_genome]
 		for line in readCsv(path_mergedBaseLoci):
 			# Initialise the generegion in the holder dict

--- a/omgene.py
+++ b/omgene.py
@@ -551,11 +551,11 @@ def align(f_in, f_out, double=False, safety = False):
 	if safety: safetyCheck(f_in, f_out, f_out)
 
 def alignVanilla(f_in, f_out):
-	callFunction("linsi --quiet " + f_in +" > "  + f_out)
+	callFunction("mafft --localpair --maxiterate 1000 --quiet " + f_in +" > "  + f_out)
 
 def alignRef(f_in, f_out, p_ref, p_refOut):
 	callFunction("sed -r \"s/>/>dummy./g\" " + p_ref + " > " + p_refOut)
-	callFunction("linsi --quiet --add " + f_in +" " + p_refOut + " > "  + f_out)
+	callFunction("mafft --localpair --maxiterate 1000 --quiet --add " + f_in +" " + p_refOut + " > "  + f_out)
 	refseqs = [a for a in readSeqs(f_out) if "dummy" in a.id]
 	writeSeqs(refseqs, p_refOut)
 	cleanDummies(f_out)
@@ -563,7 +563,7 @@ def alignRef(f_in, f_out, p_ref, p_refOut):
 def alignSeeded(list_f_in, f_out, prealigned = False, safety = False):
 	# Use each of the input fasta files as seeds. Need to double-check
 	# that they each have more than one entry.
-	functionString = "linsi --quiet "
+	functionString = "mafft --localpair --maxiterate 1000 --quiet "
 	f_all = tempfile.mktemp()
 	for f_in in list_f_in:
 		callFunction("cat " + f_in +" >> " + f_all)


### PR DESCRIPTION
I don't have the linsi or mafft-linsi aliases with my MAFFT install.  These parameters seem more robust to weird configuration issues.